### PR TITLE
belivvr-reticulum 프록시 설정

### DIFF
--- a/lib/ret_web/plugs/proxies.ex
+++ b/lib/ret_web/plugs/proxies.ex
@@ -7,3 +7,8 @@ defmodule RetWeb.Plugs.ItaProxy do
   use Plug.Builder
   plug ReverseProxyPlug, upstream: "http://localhost:6000"
 end
+
+defmodule RetWeb.Plugs.BelivvrReticulumWebProxy do
+  use Plug.Builder
+  plug ReverseProxyPlug, upstream: "http://localhost:4010"
+end

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -91,8 +91,8 @@ defmodule RetWeb.Router do
     plug (RetWeb.Plugs.InjectAdminAccount)
   end
 
-  scope "/belivvr-reticulum", BelivvrReticulumWeb do
-    get("/", BelivvrReticulumController, :index)
+  scope "/belivvr-reticulum" do
+    forward("/", RetWeb.Plugs.BelivvrReticulumWebProxy)
   end
 
   scope "/health", RetWeb do


### PR DESCRIPTION
기존 레티큘럼에 router에서 belivvr-reticulum 모듈을 사용할 경우 사용에는 문제 없으나,
git action에서 mix compile --warnings-as-errors 사용할 경우 belivvr-reticulum 모듈을 찾을 수 없어(서브 프로젝트 단계에는 분리)
warnings이 발생하여 중단되는 이슈 발생하여 프록시로(localhost:4010) belivvr-reticulum에 접근